### PR TITLE
fix: check if tooltip is set

### DIFF
--- a/src/js/Map/handleContainerEvents.js
+++ b/src/js/Map/handleContainerEvents.js
@@ -38,7 +38,9 @@ export default function handleContainerEvents() {
         offsetY = event.pageY - rect.top - window.pageYOffset,
         zoomStep = Math.pow(1 + (map.params.zoomOnScrollSpeed / 1000), -1.5 * deltaY)
 
-      map.tooltip.hide()
+      if (map.tooltip) {
+        map.tooltip.hide()
+      }
       map.setScale(map.scale * zoomStep, offsetX, offsetY)
     }, {
       // https://www.chromestatus.com/feature/5745543795965952


### PR DESCRIPTION
tooltip can be undefined tooltip is disabled.
check if tooltip is set before calling hide method
inside wheel handler. This fixes a bug that causes
zoom to fail if tooltip is not enabled.