### PR TITLE
fix: dragging the map selects the region

### DIFF
--- a/src/js/Map.js
+++ b/src/js/Map.js
@@ -38,6 +38,7 @@ class Map {
     this.transY = 0
     this.baseTransX = 0
     this.baseTransY = 0
+    this.isBeingDragged = false
 
     this.selector = options.selector
 

--- a/src/js/Map/handleContainerEvents.js
+++ b/src/js/Map/handleContainerEvents.js
@@ -12,6 +12,7 @@ export default function handleContainerEvents() {
           map.applyTransform()
           oldPageX = e.pageX
           oldPageY = e.pageY
+          this.isBeingDragged = true
         }
         return false
       }).on('mousedown', (e) => {

--- a/src/js/Map/handleElementEvents.js
+++ b/src/js/Map/handleElementEvents.js
@@ -24,8 +24,7 @@ function parseEvent(map, selector, isTooltip) {
 export default function handleElementEvents() {
   const map = this
 
-  // Prevent 
-  this.container.delegate('.jvm-element', 'mousedown', (e) => {
+  this.container.delegate('.jvm-element', 'mousedown', () => {
     this.isBeingDragged = false
   })
 

--- a/src/js/Map/handleElementEvents.js
+++ b/src/js/Map/handleElementEvents.js
@@ -24,6 +24,11 @@ function parseEvent(map, selector, isTooltip) {
 export default function handleElementEvents() {
   const map = this
 
+  // Prevent 
+  this.container.delegate('.jvm-element', 'mousedown', (e) => {
+    this.isBeingDragged = false
+  })
+
   // When the mouse is over the region/marker | When the mouse is out the region/marker
   this.container.delegate('.jvm-element', 'mouseover mouseout', function (event) {
     const data = parseEvent(map, this, true)
@@ -54,15 +59,17 @@ export default function handleElementEvents() {
   this.container.delegate('.jvm-element', 'mouseup', function (event) {
     const data = parseEvent(map, this)
 
+    if (map.isBeingDragged || event.defaultPrevented) {
+      return
+    }
+
     if (
-      data.type === 'region' && map.params.regionsSelectable ||
-      data.type === 'marker' && map.params.markersSelectable &&
-      !event.defaultPrevented
+      (data.type === 'region' && map.params.regionsSelectable) ||
+      (data.type === 'marker' && map.params.markersSelectable)
     ) {
       const ele = data.element
 
       // We're checking if regions/markers|SelectableOne option is presented
-      // clear all selected regions/markers
       if (map.params[`${data.type}sSelectableOne`]) {
         map.clearSelected(`${data.type}s`)
       }


### PR DESCRIPTION
Dragging the map with `regionsSelectable` option enabled selects the region.

Related issue: #47 