### PR TITLE
Massively improves performance when not using labels

### DIFF
--- a/src/js/components/region.js
+++ b/src/js/components/region.js
@@ -14,11 +14,12 @@ class Region extends BaseComponent {
     this._map = map
     this.shape = this._createRegion(path, code, style)
 
-    let bbox = this.shape.getBBox()
     let text = this.getLabelText(code, label)
 
     // If label is passed and render function returns something 
     if (label && text) {
+      let bbox = this.shape.getBBox()
+      
       let offsets = this.getLabelOffsets(code, label)
       this.labelX = bbox.x + bbox.width / 2 + offsets[0]
       this.labelY = bbox.y + bbox.height / 2 + offsets[1]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72016203/220293749-612141df-2cfa-48e2-8f81-7ae9ed4f718d.png)


We have a map with over 11k regions which loads very slow. In the profiler I found out that the bbox call was the issue. It calls the bbox when creating the region and uses it to place the label in the right position, but we are not using labels at all. This small change improves the loading speed of our maps over 90%.
The reason the getbbox calculation is so slow is because it has to recalculate the style and in many cases causes a reflow of the page. There might be a way to get the bbox without doing the reflow, that would be a good performance improvement for people using labels.