### PR TITLE
feat(regions): set/clear selected regions programmatically

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -158,13 +158,15 @@ class Map {
   }
 
   clearSelectedRegions(regions = undefined) {
-    if (typeof regions === 'string') {
-      regions = [regions]
-    }
-
-    ;(regions || this._getSelected('regions')).forEach((key) => {
+    regions = this._normalizeRegions(regions) || this._getSelected('regions')
+    regions.forEach((key) => {
       this.regions[key].element.select(false)
     })
+  }
+
+  setSelectedRegions(regions) {
+    this.clearSelectedRegions()
+    this._setSelected('regions', this._normalizeRegions(regions))
   }
 
   // Markers methods
@@ -330,6 +332,10 @@ class Map {
 
   _getLinesAsUids() {
     return Object.keys(this._lines)
+  }
+
+  _normalizeRegions(regions) {
+    return typeof regions === 'string' ? [regions] : regions
   }
 }
 

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -157,8 +157,14 @@ class Map {
     return this._getSelected('regions')
   }
 
-  clearSelectedRegions() {
-    this._clearSelected('regions')
+  clearSelectedRegions(regions = undefined) {
+    if (typeof regions === 'string') {
+      regions = [regions]
+    }
+
+    ;(regions || this._getSelected('regions')).forEach((key) => {
+      this.regions[key].element.select(false)
+    })
   }
 
   // Markers methods
@@ -171,10 +177,7 @@ class Map {
   }
 
   addMarkers(config) {
-    if (Array.isArray(config)) {
-      return this._createMarkers(config, true)
-    }
-
+    config = Array.isArray(config) ? config : [config]
     this._createMarkers([config], true)
   }
 


### PR DESCRIPTION
Fixes: #131 

## Clear selected regions

```js
// Clear all selected regions
map.clearSelectedRegions()

// Clear a single selected region
map.clearSelectedRegions('EG')

// Clear multiple selected regions
map.clearSelectedRegions(['EG', 'CA'])
```

## Set selected regions

```js
// Set Egypt as the only selected region
map.setSelectedRegions('EG')

// Set Egypt and Canada as the only selected regions
map.setSelectedRegions(['EG', 'CA'])
```