### PR TITLE
Fix pollyfills.js

### DIFF
--- a/src/js/util/pollyfills.js
+++ b/src/js/util/pollyfills.js
@@ -9,7 +9,7 @@ if (!Element.prototype.matches) {
       Element.prototype.webkitMatchesSelector ||
       function(s) {
         const matches = (this.document || this.ownerDocument).querySelectorAll(s)
-        const i = matches.length
+        let i = matches.length
         while (--i >= 0 && matches.item(i) !== this) {}
         return i > -1
       }


### PR DESCRIPTION
Within the polyfill for `Element.matches`, there is a variable `i` that is incorrectly marked as `const` and therefore breaks the function, as the next line decrements `i`.