### PR TITLE
feat: allow all styles on Marker level

### DIFF
--- a/src/js/core/createMarkers.js
+++ b/src/js/core/createMarkers.js
@@ -34,7 +34,7 @@ export default function createMarkers(markers = {}, isRecentlyCreated = false) {
       index,
       map: this,
       // Merge the `markerStyle` object with the marker config `style` if presented.
-      style: merge(this.params.markerStyle, { initial: config.style || {} }, true),
+      style: merge(this.params.markerStyle, { ...config.style || {} }, true),
       label: this.params.labels && this.params.labels.markers,
       labelsGroup: this._markerLabelsGroup,
       cx: point.x,


### PR DESCRIPTION
Hi @themustafaomar , 

We had an issue where due to the current implementation we were not able to define an image for hover and select states. The proposed change allows all top level Marker styles to also be added on the individual level, opposite to just initial ones. 

Thanks!