### PR TITLE
fixed dataVisualization from displaying black region when there is 1 value

### DIFF
--- a/src/js/dataVisualization.js
+++ b/src/js/dataVisualization.js
@@ -51,7 +51,7 @@ class DataVisualization {
 
   getValue(value) {
     if (this.min === this.max) {
-      return this.rgbToHex(this._toColor);
+      return this.hexToRgb(this._toColor)
     }
 
     let hex, color = '#'

--- a/src/js/dataVisualization.js
+++ b/src/js/dataVisualization.js
@@ -51,7 +51,7 @@ class DataVisualization {
 
   getValue(value) {
     if (this.min === this.max) {
-      return this.hexToRgb(this._toColor)
+      return `#${this._toColor.join('')}`
     }
 
     let hex, color = '#'

--- a/src/js/dataVisualization.js
+++ b/src/js/dataVisualization.js
@@ -50,6 +50,10 @@ class DataVisualization {
   }
 
   getValue(value) {
+    if (this.min === this.max) {
+      return this.rgbToHex(this._toColor);
+    }
+
     let hex, color = '#'
   
     for (var i = 0; i < 3; i++) {


### PR DESCRIPTION
In the `visualize()` method, colors for regions based on the provided values. However, when there's only one value, the color calculation is not being handled properly.

When you only have one value, the `getValue()` method is being called with the same value for this.min and this.max, resulting in a division by zero error. This leads to NaN making the color always black.

To address this issue we can check if the min and max value are the same and just return the _toColor as a default