### PR TITLE
feat(lines): add curved lines with curvature option

### DIFF
--- a/packages/jsvectormap/src/js/components/line.js
+++ b/packages/jsvectormap/src/js/components/line.js
@@ -1,16 +1,54 @@
 import BaseComponent from './base'
 
-class Line extends BaseComponent {
-  constructor({ index, map, style, x1, y1, x2, y2, group, config }) {
-    super()
+const LINE_CLASS = 'jvm-line'
 
-    this.config = config
-    this.shape = map.canvas.createLine({ x1, y1, x2, y2, dataIndex: index }, style, group)
-    this.shape.addClass('jvm-line')
+class Line extends BaseComponent {
+  constructor(options, style) {
+    super()
+    this._options = options
+    this._style = style
+    this._draw()
   }
 
   setStyle(property, value) {
     this.shape.setStyle(property, value)
+  }
+
+  getConfig() {
+    return this._options.config
+  }
+
+  _draw() {
+    const { index, group, map, animate } = this._options
+    const config = {
+      d: this._getDAttribute(),
+      fill: 'none',
+      dataIndex: index,
+    }
+
+    this.shape = map.canvas.createPath(config, this._style, group)
+    this.shape.addClass(LINE_CLASS)
+
+    if (animate) {
+      this.shape.setStyle({ animation: true })
+    }
+  }
+
+  _getDAttribute() {
+    const { x1, y1, x2, y2 } = this._options
+    return `M${x1},${y1}${this._getQCommand(x1, y1, x2, y2)}${x2},${y2}`
+  }
+
+  _getQCommand(x1, y1, x2, y2) {
+    if (!this._options.curvature) {
+      return ' '
+    }
+
+    const curvature = this._options.curvature || 0.6
+    const curveX = (x1 + x2) / 2 + curvature * (y2 - y1)
+    const curveY = (y1 + y2) / 2 - curvature * (x2 - x1)
+
+    return ` Q${curveX},${curveY} `
   }
 }
 

--- a/packages/jsvectormap/src/js/core/repositionLines.js
+++ b/packages/jsvectormap/src/js/core/repositionLines.js
@@ -1,26 +1,27 @@
 export default function repositionLines() {
-  let point1 = false, point2 = false
+  const curvature = this.params.lines.curvature || 0.5
 
-  for (let index in this._lines) {
-    for (let mindex in this._markers) {
-      const marker = this._markers[mindex]
+  Object.values(this._lines).forEach((line) => {
+    const startMarker = Object.values(this._markers).find(
+      ({ config }) => config.name === line.getConfig().from
+    )
 
-      if (marker.config.name === this._lines[index].config.from) {
-        point1 = this.getMarkerPosition(marker.config)
-      }
+    const endMarker = Object.values(this._markers).find(
+      ({ config }) => config.name === line.getConfig().to
+    )
 
-      if (marker.config.name === this._lines[index].config.to) {
-        point2 = this.getMarkerPosition(marker.config)
-      }
-    }
+    if (startMarker && endMarker) {
+      const { x: x1, y: y1 } = this.getMarkerPosition(startMarker.config)
+      const { x: x2, y: y2 } = this.getMarkerPosition(endMarker.config)
 
-    if (point1 !== false && point2 !== false) {
-      this._lines[index].setStyle({
-        x1: point1.x,
-        y1: point1.y,
-        x2: point2.x,
-        y2: point2.y,
+      const midX = (x1 + x2) / 2
+      const midY = (y1 + y2) / 2
+      const curveX = midX + curvature * (y2 - y1)
+      const curveY = midY - curvature * (x2 - x1)
+
+      line.setStyle({
+        d: `M${x1},${y1} Q${curveX},${curveY} ${x2},${y2}`,
       })
     }
-  }
+  })
 }

--- a/packages/jsvectormap/src/js/defaults/options.js
+++ b/packages/jsvectormap/src/js/defaults/options.js
@@ -13,10 +13,12 @@ export default {
   bindTouchEvents: true,
 
   // Line options
-  lineStyle: {
-    stroke: '#808080',
-    strokeWidth: 1,
-    strokeLinecap: 'round',
+  lines: {
+    style: {
+      stroke: '#808080',
+      strokeWidth: 1,
+      strokeLinecap: 'round',
+    }
   },
 
   // Marker options

--- a/packages/jsvectormap/src/js/map.js
+++ b/packages/jsvectormap/src/js/map.js
@@ -71,7 +71,7 @@ class Map {
     this.updateSize()
 
     // Create lines
-    this._createLines(options.lines || {}, options.markers || {})
+    this._createLines(options.lines.elements || {})
 
     // Create markers
     this._createMarkers(options.markers)

--- a/packages/jsvectormap/src/js/svg/canvasElement.js
+++ b/packages/jsvectormap/src/js/svg/canvasElement.js
@@ -35,12 +35,12 @@ class SVGCanvasElement extends SVGElement {
   }
 
   // Create `path` element
-  createPath(config, style) {
+  createPath(config, style, group) {
     const path = new SVGShapeElement('path', config, style)
 
     path.node.setAttribute('fill-rule', 'evenodd')
 
-    return this._add(path)
+    return this._add(path, group)
   }
 
   // Create `circle` element


### PR DESCRIPTION
This PR adds the ability to curve lines with optional curvature option.

![Screenshot 2024-08-17 004517-min](https://github.com/user-attachments/assets/d99112e0-365b-4dc7-acc8-9f7c7f075031)

## BREAKING CHANGES

Lines will be configured via `lines` key only instead of `lineStyle` and `lines` keys.

```js
const map = new jsVectorMap({
  ...
  lines: {
    curvature: -0.5,
    animate: true,
    elements: lines,
    style: {
      stroke: '#333',
      strokeDasharray: '2 4 2',
      strokeWidth: 0.5,
    },
  },
  ...
})
```