### PR TITLE
feat: support custom zoom buttons

### DIFF
--- a/packages/jsvectormap/src/js/core/setupZoomButtons.js
+++ b/packages/jsvectormap/src/js/core/setupZoomButtons.js
@@ -2,11 +2,28 @@ import { createElement } from '../util'
 import EventHandler from '../eventHandler'
 
 export default function setupZoomButtons() {
-  const zoomin = createElement('div', 'jvm-zoom-btn jvm-zoomin', '&#43;', true)
-  const zoomout = createElement('div', 'jvm-zoom-btn jvm-zoomout', '&#x2212', true)
+  const zoomInOption = this.params.zoomInButton
+  const zoomOutOption = this.params.zoomOutButton
 
-  this.container.appendChild(zoomin)
-  this.container.appendChild(zoomout)
+  const getZoomButton = (zoomOption) => typeof zoomOption === 'string'
+    ? document.querySelector(zoomOption)
+    : zoomOption
+
+  const zoomIn = this.params.zoomInButton
+    ? getZoomButton(zoomInOption)
+    : createElement('div', 'jvm-zoom-btn jvm-zoomin', '&#43;', true)
+
+  const zoomOut = zoomOutOption
+    ? getZoomButton(zoomOutOption)
+    : createElement('div', 'jvm-zoom-btn jvm-zoomout', '&#x2212', true)
+
+  if (!zoomInOption) {
+    this.container.appendChild(zoomIn)
+  }
+
+  if (!zoomOutOption) {
+    this.container.appendChild(zoomOut)
+  }
 
   const handler = (zoomin = true) => {
     return () => this._setScale(

--- a/packages/jsvectormap/src/js/core/setupZoomButtons.js
+++ b/packages/jsvectormap/src/js/core/setupZoomButtons.js
@@ -35,6 +35,6 @@ export default function setupZoomButtons() {
     )
   }
 
-  EventHandler.on(zoomin, 'click', handler())
-  EventHandler.on(zoomout, 'click', handler(false))
+  EventHandler.on(zoomIn, 'click', handler())
+  EventHandler.on(zoomOut, 'click', handler(false))
 }


### PR DESCRIPTION
Resolves #144

Adding multiple options to support custom progrmatic zoom buttons:

```js
  // Using a selector
  ...
  zoomInButton: '#zoomin',
  zoomOutButton: '#zoomout',

  // Using an element.
  zoomInButton: document.querySelector('#zoomin'),
  zoomOutButton: document.querySelector('#zoomout'),
  ...
```