### PR TITLE
fix(tooltip): internal text overrides text from listeners

### DIFF
--- a/packages/jsvectormap/src/js/core/setupElementEvents.js
+++ b/packages/jsvectormap/src/js/core/setupElementEvents.js
@@ -50,9 +50,9 @@ export default function setupElementEvents() {
       data.element.hover(true)
 
       if (showTooltip) {
+        map._tooltip.text(data.tooltipText)
         map._emit(data.event, [event, map._tooltip, data.code])
         if (!event.defaultPrevented) {
-          map._tooltip.text(data.tooltipText)
           map._tooltip.show()
         }
       }


### PR DESCRIPTION
This PR fixes:

The internal text method overrides text from listeners like `onRegionTooltipShow` and `onMarkerTooltipShow` if presented.