### PR TITLE
revert: revert old lineStyle config to maintain compatibility

### DIFF
--- a/packages/jsvectormap/src/js/components/line.js
+++ b/packages/jsvectormap/src/js/components/line.js
@@ -6,7 +6,7 @@ class Line extends BaseComponent {
   constructor(options, style) {
     super()
     this._options = options
-    this._style = style
+    this._style = { initial: style }
     this._draw()
   }
 
@@ -19,7 +19,7 @@ class Line extends BaseComponent {
   }
 
   _draw() {
-    const { index, group, map, animate } = this._options
+    const { index, group, map } = this._options
     const config = {
       d: this._getDAttribute(),
       fill: 'none',
@@ -28,23 +28,18 @@ class Line extends BaseComponent {
 
     this.shape = map.canvas.createPath(config, this._style, group)
     this.shape.addClass(LINE_CLASS)
-
-    if (animate) {
-      this.shape.setStyle({ animation: true })
-    }
   }
 
   _getDAttribute() {
-    const { x1, y1, x2, y2 } = this._options
-    return `M${x1},${y1}${this._getQCommand(x1, y1, x2, y2)}${x2},${y2}`
+    const { x1, y1, x2, y2, curvature } = this._options
+    return `M${x1},${y1}${this._getQCommand(x1, y1, x2, y2, curvature)}${x2},${y2}`
   }
 
-  _getQCommand(x1, y1, x2, y2) {
-    if (!this._options.curvature) {
+  _getQCommand(x1, y1, x2, y2, curvature) {
+    if (!curvature) {
       return ' '
     }
 
-    const curvature = this._options.curvature || 0.6
     const curveX = (x1 + x2) / 2 + curvature * (y2 - y1)
     const curveY = (y1 + y2) / 2 - curvature * (x2 - x1)
 

--- a/packages/jsvectormap/src/js/core/createLines.js
+++ b/packages/jsvectormap/src/js/core/createLines.js
@@ -2,15 +2,13 @@ import { merge, getLineUid } from '../util'
 import Line from '../components/line'
 
 export default function createLines(lines) {
-  const markers = this._markers
-  const { style, elements: _, ...rest } = this.params.lines
-
   let point1 = false, point2 = false
+  const { curvature, ...lineStyle } = this.params.lineStyle
 
   for (let index in lines) {
     const lineConfig = lines[index]
 
-    for (let { config: markerConfig } of Object.values(markers)) {
+    for (let { config: markerConfig } of Object.values(this._markers)) {
       if (markerConfig.name === lineConfig.from) {
         point1 = this.getMarkerPosition(markerConfig)
       }
@@ -21,6 +19,11 @@ export default function createLines(lines) {
     }
 
     if (point1 !== false && point2 !== false) {
+      const {
+        curvature: curvatureOption,
+        ...style
+      } = lineConfig.style || {}
+
       // Register lines with unique keys
       this._lines[getLineUid(lineConfig.from, lineConfig.to)] = new Line(
         {
@@ -32,9 +35,9 @@ export default function createLines(lines) {
           y1: point1.y,
           x2: point2.x,
           y2: point2.y,
-          ...rest,
+          curvature: curvatureOption == 0 ? 0 : (curvatureOption || curvature),
         },
-        merge({ initial: style }, { initial: lineConfig.style || {} }, true)
+        merge(lineStyle, style, true)
       )
     }
   }

--- a/packages/jsvectormap/src/js/core/repositionLines.js
+++ b/packages/jsvectormap/src/js/core/repositionLines.js
@@ -1,5 +1,5 @@
 export default function repositionLines() {
-  const curvature = this.params.lines.curvature || 0.5
+  const curvature = this.params.lineStyle.curvature
 
   Object.values(this._lines).forEach((line) => {
     const startMarker = Object.values(this._markers).find(
@@ -16,8 +16,8 @@ export default function repositionLines() {
 
       const midX = (x1 + x2) / 2
       const midY = (y1 + y2) / 2
-      const curveX = midX + curvature * (y2 - y1)
-      const curveY = midY - curvature * (x2 - x1)
+      const curveX = midX + (line._options.curvature || curvature) * (y2 - y1)
+      const curveY = midY - (line._options.curvature || curvature) * (x2 - x1)
 
       line.setStyle({
         d: `M${x1},${y1} Q${curveX},${curveY} ${x2},${y2}`,

--- a/packages/jsvectormap/src/js/defaults/options.js
+++ b/packages/jsvectormap/src/js/defaults/options.js
@@ -13,12 +13,11 @@ export default {
   bindTouchEvents: true,
 
   // Line options
-  lines: {
-    style: {
-      stroke: '#808080',
-      strokeWidth: 1,
-      strokeLinecap: 'round',
-    }
+  lineStyle: {
+    curvature: 0,
+    stroke: '#808080',
+    strokeWidth: 1,
+    strokeLinecap: 'round',
   },
 
   // Marker options

--- a/packages/jsvectormap/src/js/map.js
+++ b/packages/jsvectormap/src/js/map.js
@@ -81,7 +81,7 @@ class Map {
 
     // Lines group must be created before markers
     // Otherwise the lines will be drawn on top of the markers.
-    if (options.lines.elements) {
+    if (options.lines) {
       this._linesGroup = this.canvas.createGroup(LINES_GROUP_ID)
     }
 
@@ -94,7 +94,7 @@ class Map {
     this._createMarkers(options.markers)
 
     // Create lines
-    this._createLines(options.lines.elements || {})
+    this._createLines(options.lines || {})
 
     // Position labels
     this._repositionLabels()


### PR DESCRIPTION
Reverted to old `lineStyle` config to maintain compatibility and avoid breaking changes.